### PR TITLE
Seperate buggy and jalopy

### DIFF
--- a/mp/game/mod_sdk2013ce/scripts/surfaceproperties_ep2.txt
+++ b/mp/game/mod_sdk2013ce/scripts/surfaceproperties_ep2.txt
@@ -1,0 +1,131 @@
+// "surface group" 
+// { 
+// "property" 	"value"
+// ...
+// }
+//
+// thickness: If this value is present, the material is not volumetrically solid
+// it means that the volume should be computed as the surface area times this
+// thickness (for automatic mass).  The inside space beneath the thickness value is air.
+//
+// physics parameters are:
+// density: this is the material density in kg / m^3 (water is 1000)
+// elasticity: This is the collision elasticity (0 - 1.0, 0.01 is soft, 1.0 is hard)
+// friction: this is the physical friction (0 - 1.0, 0.01 is slick, 1.0 is totally rough)
+// dampening: this is the physical drag on an object when in contact with this surface (0 - x, 0 none to x a lot)
+//
+// !!! Do not edit the physics properties (especially density) without the proper references !!!
+//`
+// Sounds
+// 
+// stepleft: footstep sound for left foot
+// stepright: footstep sound for right foot
+// impactsoft: Physical impact sound when hitting soft surfaces
+// impacthard: Physical impact sound when hitting hard surfaces
+// scrapesmooth: Looping physics friction sound (when scraping smooth surfaces)
+// scraperough: Looping physics friction sound (when scraping rough surfaces)
+// bulletimpact: bullet impact sound
+// gamematerial: game material index (can be a single letter or a number)
+// 
+
+// NOTE: The properties of "default" will get copied into EVERY material who does not
+// 	 override them!!!
+//
+// "base" means to use the parameters from that material as a base.
+// "base" must appear as the first key in a material
+//
+
+"cavern_rock"
+{
+	"base"  "rock"
+	
+	"density" "700"
+	"elasticity" "0.1"
+	"friction" "0.8"
+	"bulletimpact" "CavernRock.ImpactHard"
+	"scraperough"	"Rock.ImpactHard"
+	"scrapesmooth"	"Rock.ImpactSoft"
+	"impacthard" "CavernRock.ImpactHard"
+	"impactsoft" "CavernRock.ImpactSoft"
+	
+	"gamematerial" "O"
+}
+
+"advisor_shield"
+{
+ "base"  "rock"
+ 
+ "density" "700"
+ "elasticity" "0.1"
+ "friction" "0.8"
+ "bulletimpact" "NPC_Advisor.shieldblock"
+ "scraperough" "NPC_Advisor.shieldblock"
+ "scrapesmooth" "NPC_Advisor.shieldblock"
+ "impacthard" "NPC_Advisor.shieldblock"
+ "impactsoft" "NPC_Advisor.shieldblock"
+ 
+ "gamematerial" "Z"  // <--- Whatever you make the character index in decals.h
+}
+
+"antlion_eggshell"
+{
+ "base"  "flesh"
+"bulletimpact"	"Flesh.ImpactHard"
+"impacthard"	"Flesh.ImpactHard"
+"impactsoft"	"Flesh.ImpactHard"
+
+ "gamematerial" "E"
+}
+
+
+"hunter"
+{
+	"base" "flesh"
+	"gamematerial" "F"
+}
+
+"jalopytire"
+{
+	"base"			"jeeptire"
+	"elasticity"		"0.1"
+}
+
+"slidingrubbertire_jalopyfront"
+{
+	"base"			"jalopytire"
+	"friction"		"0.15"
+}
+
+"slidingrubbertire_jalopyrear"
+{
+	"base"			"jalopytire"
+	"friction"		"0.15"
+}
+
+"water"
+{
+	"density"	"1000"
+	"elasticity"	"0.1"
+	"friction"	"0.8"
+
+	"stepleft"	"Water.StepLeft"
+	"stepright"	"Water.StepRight"
+	"bulletimpact"	"Water.BulletImpact"
+
+	"impacthard" "Water.ImpactHard"
+	"impactsoft" "Water.ImpactSoft"
+
+	"audioreflectivity" "0.33"
+	"audioroughnessfactor" "0.1"
+	"audiohardnessfactor" "0.0"
+
+	"gamematerial"	"S"
+}
+
+"jalopy"
+{
+	"base"			"metal"
+	"impacthard"	"ATV_impact_medium"
+	"impactsoft"	"ATV_impact_medium"
+}
+

--- a/mp/game/mod_sdk2013ce/sdk2013ce.fgd
+++ b/mp/game/mod_sdk2013ce/sdk2013ce.fgd
@@ -1,4 +1,4 @@
-//====== Copyright © 1996-2005, Valve Corporation, All rights reserved. =======
+//========= Copyright Valve Corporation, All rights reserved. ============//
 //
 // Purpose: SDK 2013 CE game definition file (.fgd) 
 //

--- a/mp/game/mod_sdk2013ce/sdk2013ce.fgd
+++ b/mp/game/mod_sdk2013ce/sdk2013ce.fgd
@@ -1,0 +1,130 @@
+//====== Copyright © 1996-2005, Valve Corporation, All rights reserved. =======
+//
+// Purpose: SDK 2013 CE game definition file (.fgd) 
+//
+//=============================================================================
+
+@include "base.fgd"
+
+//-------------------------------------------------------------------------
+//
+// NPCs
+//
+//-------------------------------------------------------------------------
+@NPCClass base(BaseHelicopter) studio("models/combine_dropship.mdl" ) = npc_combinedropship : "Combine Dropship"
+[
+	spawnflags(Flags) =
+	[
+		32768 : "Wait for input before dropoff" : 0
+	]
+
+	LandTarget(target_destination) : "Land target name"
+	GunRange(float) : "Crate Gun Range" : 2048 : "If the dropship's carrying a crate with a gun on it, it'll only shoot targets within this range."
+
+	RollermineTemplate(target_destination) : "Name of Rollermine Template" : "" : "If this dropship drops any rollermines due to the 'DropMines' input being fired, it will use this template for the rollermines it creates. If left blank, ordinary rollermines will be dropped."
+
+	NPCTemplate(target_destination) : "Name of Template NPC 1"
+	NPCTemplate2(target_destination) : "Name of Template NPC 2"
+	NPCTemplate3(target_destination) : "Name of Template NPC 3"
+	NPCTemplate4(target_destination) : "Name of Template NPC 4"
+	NPCTemplate5(target_destination) : "Name of Template NPC 5"
+	NPCTemplate6(target_destination) : "Name of Template NPC 6"
+
+	Dustoff1(target_destination) : "Name of dustoff point for NPC 1"
+	Dustoff2(target_destination) : "Name of dustoff point for NPC 2"
+	Dustoff3(target_destination) : "Name of dustoff point for NPC 3"
+	Dustoff4(target_destination) : "Name of dustoff point for NPC 4"
+	Dustoff5(target_destination) : "Name of dustoff point for NPC 5"
+	Dustoff6(target_destination) : "Name of dustoff point for NPC 6"
+
+	APCVehicleName(target_destination) : "Name of the APC to drop"
+	Invulnerable(Choices) : "Invulnerable" : 0 =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	CrateType(Choices) : "Crate Type" : 2 =
+	[
+		-4 : "Jalopy (No crate)"
+		-3 : "Jeep (No crate)"
+		-2 : "APC (No crate)"
+		-1 : "Strider (No crate)"
+		0 : "Roller Hopper"
+		1 : "Soldier Crate"
+		2 : "None"
+	]
+
+	// Inputs
+	input LandLeaveCrate(integer) : "Land, drop soldiers, and leave the crate behind. Specify the number of troops to drop off in the parameter."
+	input LandTakeCrate(integer) : "Land, drop soldiers, but don't leave the crate behind. Specify the number of troops to drop off in the parameter."
+	input DropMines(integer) : "Drop Rollermines. Specify the number of mines to drop in the parameter."
+	input DropStrider(void) : "Drop the Strider you're carrying. Now."
+	input DropAPC(void) : "Drop the APC you're carrying. Now."
+	input Hover(target_destination) : "Hover over a named target entity until told to fly to a path."
+	input Pickup(string) : "Pickup an entity."
+	input SetLandTarget(string) : "Set my land target name."
+	input SetGunRange(float) : "Set my crate gun's range."
+
+	input EnableRotorSound(void) : "Turns on rotor sounds"
+	input DisableRotorSound(void) : "Turns off rotor sounds"
+
+	input StopWaitingForDropoff(void) : "Stop waiting for the dropoff. Dropoff as soon as possible."
+
+
+	// Outputs
+	output OnFinishedDropoff(void)  : "Fires when the dropship has finished a dropoff."
+	output OnFinishedPickup(void) : "Fires when the dropship has finished a pickup."
+
+	output OnCrateShotDownBeforeDropoff(float) : "Fires when the container was shot down before it dropped off soldiers. The parameter contains the number of soldiers that weren't successfully dropped off."
+	output OnCrateShotDownAfterDropoff(void) : "Fires when the container was shot down after it dropped off soldiers."
+
+]
+
+//-------------------------------------------------------------------------
+//
+// Vehicles.
+//
+//-------------------------------------------------------------------------
+@PointClass base(BaseDriveableVehicle) studioprop() = prop_vehicle_jalopy :
+	"Driveable studiomodel jalopy."
+[
+	input StartRemoveTauCannon(void) : "Start the tau removal sequence."
+	input FinishRemoveTauCannon(void) : "Finish the tau removal sequence."
+	
+	// FIXME: These will move into episodic
+	input LockEntrance( void ) : "Stops NPC's from entering the vehicle until unlocked."
+	input UnlockEntrance( void ) : "Allows NPC's to enter the vehicle."
+	input LockExit( void ) : "Stops NPC's from exiting the vehicle until unlocked."
+	input UnlockExit( void ) : "Allows NPC's to exit the vehicle."
+	input EnableRadar( void ) : "Turn on the Jalopy radar"
+	input DisableRadar( void ) : "Turn off the Jalopy radar"
+	input EnableRadarDetectEnemies( void ) : "Enable Jalopy radar to detect Striders and Hunters"
+	input AddBusterToCargo( void ) : "Put a striderbuster in the cargo trigger"
+	input SetCargoHopperVisibility ( bool ) : "Set the strider buster hopper thingy to be visible, or invisible."
+
+	input DisablePhysGun(void) : "Disable physgun interactions with the jeep."
+	input EnablePhysGun(void) : "Enable physgun interactions with the jeep (default)."
+
+	input CreateLinkController(void) : "Automatically builds and attaches a link controller to the car, which cuts the node connections under the car while the car is standing still."
+	input DestroyLinkController(void) : "Destroys the link controller created by CreateLinkController."
+
+	
+	CargoVisible(choices): "Hopper Visible" : 0 : "Is the striderbuster cargo hopper visible?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	spawnflags(Flags) = 
+	[
+		1 : "HUD Locator Precache" : 0
+	]
+
+	
+	// FIXME: These are going to change!
+	output OnCompanionEnteredVehicle(void) : "Companion has entered the vehicle."
+	output OnCompanionExitedVehicle(void) : "Companion has exited the vehicle."
+	output OnHostileEnteredVehicle(void) : "Hostile has entered the vehicle."
+	output OnHostileExitedVehicle(void) : "Hostile has exited the vehicle."
+]

--- a/mp/src/game/server/episodic/vehicle_jeep_episodic.cpp
+++ b/mp/src/game/server/episodic/vehicle_jeep_episodic.cpp
@@ -314,7 +314,11 @@ LINK_ENTITY_TO_CLASS( info_target_vehicle_transition, CInfoTargetVehicleTransiti
 //	CPropJeepEpisodic
 //
 
+#ifdef SDK2013CE
+LINK_ENTITY_TO_CLASS( prop_vehicle_jalopy, CPropJeepEpisodic );
+#else
 LINK_ENTITY_TO_CLASS( prop_vehicle_jeep, CPropJeepEpisodic );
+#endif // SDK2013CE
 
 BEGIN_DATADESC( CPropJeepEpisodic )
 

--- a/mp/src/game/server/episodic/weapon_striderbuster.cpp
+++ b/mp/src/game/server/episodic/weapon_striderbuster.cpp
@@ -270,7 +270,11 @@ void CWeaponStriderBuster::Spawn( void )
 //-----------------------------------------------------------------------------
 void CWeaponStriderBuster::Activate( void )
 {	
+#ifdef SDK2013CE
+	g_iszVehicle = AllocPooledString( "prop_vehicle_jalopy" );
+#else
 	g_iszVehicle = AllocPooledString( "prop_vehicle_jeep" );
+#endif // SDK2013CE
 	BaseClass::Activate();
 }
 

--- a/mp/src/game/server/hl2/item_itemcrate.cpp
+++ b/mp/src/game/server/hl2/item_itemcrate.cpp
@@ -166,8 +166,14 @@ int CItem_ItemCrate::OnTakeDamage( const CTakeDamageInfo &info )
 void CItem_ItemCrate::VPhysicsCollision( int index, gamevcollisionevent_t *pEvent )
 {
 	float flDamageScale = 1.0f;
+#ifndef SDK2013CE
 	if ( FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_airboat" ) ||
 		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep" ) )
+#else
+	if ( FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_airboat" ) ||
+		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep" ) ||
+		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jalopy" ) )
+#endif // SDK2013CE
 	{
 		flDamageScale = 100.0f;
 	}

--- a/mp/src/game/server/hl2/npc_combinedropship.cpp
+++ b/mp/src/game/server/hl2/npc_combinedropship.cpp
@@ -84,6 +84,9 @@ enum DROP_STATES
 
 enum CRATE_TYPES 
 {
+#ifdef SDK2013CE
+	CRATE_JALOPY = -4,
+#endif // SDK2013CE
 	CRATE_JEEP = -3,
 	CRATE_APC = -2,
 	CRATE_STRIDER = -1,
@@ -973,6 +976,31 @@ void CNPC_CombineDropship::Spawn( void )
 		}
 		break;
 
+#ifdef SDK2013CE
+	case CRATE_JALOPY:
+		m_hContainer = (CBaseAnimating*)CreateEntityByName( "prop_dynamic_override" );
+		if (m_hContainer)
+		{
+			m_hContainer->SetModel( "models/vehicle.mdl" );
+			m_hContainer->SetName( AllocPooledString( "dropship_jalopy" ) );
+
+			m_hContainer->SetAbsOrigin( GetAbsOrigin() );//- Vector( 0, 0 , 25 ) );
+			QAngle angles = GetAbsAngles();
+			VMatrix mat, rot, result;
+			MatrixFromAngles( angles, mat );
+			MatrixBuildRotateZ( rot, -90 );
+			MatrixMultiply( mat, rot, result );
+			MatrixToAngles( result, angles );
+			m_hContainer->SetAbsAngles( angles );
+
+			m_hContainer->SetParent(this, 0);
+			m_hContainer->SetOwnerEntity(this);
+			m_hContainer->SetSolid( SOLID_VPHYSICS );
+			m_hContainer->Spawn();
+		}
+		break;
+#endif // SDK2013CE
+
 	case CRATE_NONE:
 	default:
 		break;
@@ -1108,6 +1136,12 @@ void CNPC_CombineDropship::Precache( void )
 	case CRATE_JEEP:
 		PrecacheModel("models/buggy.mdl");
 		break;
+		
+#ifdef SDK2013CE
+	case CRATE_JALOPY:
+		PrecacheModel("models/vehicle.mdl");
+		break;
+#endif // SDK2013CE
 
 	default:
 		break;

--- a/mp/src/game/server/hl2/vehicle_jeep.cpp
+++ b/mp/src/game/server/hl2/vehicle_jeep.cpp
@@ -144,7 +144,7 @@ IMPLEMENT_SERVERCLASS_ST( CPropJeep, DT_PropJeep )
 END_SEND_TABLE();
 
 // This is overriden for the episodic jeep
-#ifndef HL2_EPISODIC
+#if !defined(HL2_EPISODIC) || defined(SDK2013CE)
 LINK_ENTITY_TO_CLASS( prop_vehicle_jeep, CPropJeep );
 #endif
 

--- a/mp/src/game/server/physobj.cpp
+++ b/mp/src/game/server/physobj.cpp
@@ -1639,7 +1639,11 @@ void CPhysMagnet::VPhysicsCollision( int index, gamevcollisionevent_t *pEvent )
 	if ( HasSpawnFlags( SF_MAGNET_COAST_HACK ) )
 	{
 		// If the other isn't the jeep, we need to get rid of it
+#ifdef SDK2013CE
+		if ( !FClassnameIs( pOther, "prop_vehicle_jalopy" ) )
+#else
 		if ( !FClassnameIs( pOther, "prop_vehicle_jeep" ) )
+#endif // SDK2013CE
 		{
 			// If it takes damage, destroy it
 			if ( pOther->m_takedamage != DAMAGE_NO && pOther->m_takedamage != DAMAGE_EVENTS_ONLY )

--- a/mp/src/game/server/player.cpp
+++ b/mp/src/game/server/player.cpp
@@ -6001,7 +6001,11 @@ static void CreateJalopy( CBasePlayer *pPlayer )
 	// Cheat to create a jeep in front of the player
 	Vector vecForward;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward );
-	CBaseEntity *pJeep = (CBaseEntity *)CreateEntityByName( "prop_vehicle_jeep" );
+#ifdef SDK2013CE
+	CBaseEntity *pJeep = (CBaseEntity *)CreateEntityByName( "prop_vehicle_jalopy" );
+#else
+	CBaseEntity* pJeep = (CBaseEntity *)CreateEntityByName( "prop_vehicle_jeep" );
+#endif // SDK2013CE
 	if ( pJeep )
 	{
 		Vector vecOrigin = pPlayer->GetAbsOrigin() + vecForward * 256 + Vector(0,0,64);
@@ -6010,7 +6014,11 @@ static void CreateJalopy( CBasePlayer *pPlayer )
 		pJeep->SetAbsAngles( vecAngles );
 		pJeep->KeyValue( "model", "models/vehicle.mdl" );
 		pJeep->KeyValue( "solid", "6" );
-		pJeep->KeyValue( "targetname", "jeep" );
+#ifdef SDK2013CE
+		pJeep->KeyValue( "targetname", "jalopy" );
+#else
+		pJeep->KeyValue("targetname", "jeep");
+#endif // SDK2013CE
 		pJeep->KeyValue( "vehiclescript", "scripts/vehicles/jalopy.txt" );
 		DispatchSpawn( pJeep );
 		pJeep->Activate();

--- a/mp/src/game/shared/episodic/achievements_ep2.cpp
+++ b/mp/src/game/shared/episodic/achievements_ep2.cpp
@@ -60,7 +60,11 @@ protected:
 	virtual void Init() 
 	{
 		SetFlags( ACH_LISTEN_KILL_ENEMY_EVENTS | ACH_SAVE_WITH_GAME );
+#ifdef SDK2013CE
+		SetInflictorFilter( "prop_vehicle_jalopy" );
+#else
 		SetInflictorFilter( "prop_vehicle_jeep" );
+#endif // SDK2013CE
 		SetGameDirFilter( "ep2" );
 		SetGoal( 20 );
 	}

--- a/mp/src/public/steam/steam_api.h
+++ b/mp/src/public/steam/steam_api.h
@@ -594,7 +594,8 @@ inline bool CSteamAPIContext::Init()
 		return false;
 	}
 
-	/*m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
+#ifndef SDK2013CE
+	m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
 	if ( !m_pSteamMusicRemote )
 	{
 		return false;
@@ -604,7 +605,8 @@ inline bool CSteamAPIContext::Init()
 	if ( !m_pSteamHTMLSurface )
 	{
 		return false;
-	}*/
+	}
+#endif // !SDK2013CE
 
 #ifdef _PS3
 	m_pSteamPS3OverlayRender = SteamClient()->GetISteamPS3OverlayRender();

--- a/mp/src/public/steam/steam_api.h
+++ b/mp/src/public/steam/steam_api.h
@@ -594,7 +594,7 @@ inline bool CSteamAPIContext::Init()
 		return false;
 	}
 
-	m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
+	/*m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
 	if ( !m_pSteamMusicRemote )
 	{
 		return false;
@@ -604,7 +604,7 @@ inline bool CSteamAPIContext::Init()
 	if ( !m_pSteamHTMLSurface )
 	{
 		return false;
-	}
+	}*/
 
 #ifdef _PS3
 	m_pSteamPS3OverlayRender = SteamClient()->GetISteamPS3OverlayRender();

--- a/mp/src/public/steam/steam_api.h
+++ b/mp/src/public/steam/steam_api.h
@@ -594,7 +594,6 @@ inline bool CSteamAPIContext::Init()
 		return false;
 	}
 
-#ifndef SDK2013CE
 	m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
 	if ( !m_pSteamMusicRemote )
 	{
@@ -606,7 +605,6 @@ inline bool CSteamAPIContext::Init()
 	{
 		return false;
 	}
-#endif // !SDK2013CE
 
 #ifdef _PS3
 	m_pSteamPS3OverlayRender = SteamClient()->GetISteamPS3OverlayRender();

--- a/sp/game/mod_sdk2013ce/scripts/surfaceproperties_ep2.txt
+++ b/sp/game/mod_sdk2013ce/scripts/surfaceproperties_ep2.txt
@@ -1,0 +1,131 @@
+// "surface group" 
+// { 
+// "property" 	"value"
+// ...
+// }
+//
+// thickness: If this value is present, the material is not volumetrically solid
+// it means that the volume should be computed as the surface area times this
+// thickness (for automatic mass).  The inside space beneath the thickness value is air.
+//
+// physics parameters are:
+// density: this is the material density in kg / m^3 (water is 1000)
+// elasticity: This is the collision elasticity (0 - 1.0, 0.01 is soft, 1.0 is hard)
+// friction: this is the physical friction (0 - 1.0, 0.01 is slick, 1.0 is totally rough)
+// dampening: this is the physical drag on an object when in contact with this surface (0 - x, 0 none to x a lot)
+//
+// !!! Do not edit the physics properties (especially density) without the proper references !!!
+//`
+// Sounds
+// 
+// stepleft: footstep sound for left foot
+// stepright: footstep sound for right foot
+// impactsoft: Physical impact sound when hitting soft surfaces
+// impacthard: Physical impact sound when hitting hard surfaces
+// scrapesmooth: Looping physics friction sound (when scraping smooth surfaces)
+// scraperough: Looping physics friction sound (when scraping rough surfaces)
+// bulletimpact: bullet impact sound
+// gamematerial: game material index (can be a single letter or a number)
+// 
+
+// NOTE: The properties of "default" will get copied into EVERY material who does not
+// 	 override them!!!
+//
+// "base" means to use the parameters from that material as a base.
+// "base" must appear as the first key in a material
+//
+
+"cavern_rock"
+{
+	"base"  "rock"
+	
+	"density" "700"
+	"elasticity" "0.1"
+	"friction" "0.8"
+	"bulletimpact" "CavernRock.ImpactHard"
+	"scraperough"	"Rock.ImpactHard"
+	"scrapesmooth"	"Rock.ImpactSoft"
+	"impacthard" "CavernRock.ImpactHard"
+	"impactsoft" "CavernRock.ImpactSoft"
+	
+	"gamematerial" "O"
+}
+
+"advisor_shield"
+{
+ "base"  "rock"
+ 
+ "density" "700"
+ "elasticity" "0.1"
+ "friction" "0.8"
+ "bulletimpact" "NPC_Advisor.shieldblock"
+ "scraperough" "NPC_Advisor.shieldblock"
+ "scrapesmooth" "NPC_Advisor.shieldblock"
+ "impacthard" "NPC_Advisor.shieldblock"
+ "impactsoft" "NPC_Advisor.shieldblock"
+ 
+ "gamematerial" "Z"  // <--- Whatever you make the character index in decals.h
+}
+
+"antlion_eggshell"
+{
+ "base"  "flesh"
+"bulletimpact"	"Flesh.ImpactHard"
+"impacthard"	"Flesh.ImpactHard"
+"impactsoft"	"Flesh.ImpactHard"
+
+ "gamematerial" "E"
+}
+
+
+"hunter"
+{
+	"base" "flesh"
+	"gamematerial" "F"
+}
+
+"jalopytire"
+{
+	"base"			"jeeptire"
+	"elasticity"		"0.1"
+}
+
+"slidingrubbertire_jalopyfront"
+{
+	"base"			"jalopytire"
+	"friction"		"0.15"
+}
+
+"slidingrubbertire_jalopyrear"
+{
+	"base"			"jalopytire"
+	"friction"		"0.15"
+}
+
+"water"
+{
+	"density"	"1000"
+	"elasticity"	"0.1"
+	"friction"	"0.8"
+
+	"stepleft"	"Water.StepLeft"
+	"stepright"	"Water.StepRight"
+	"bulletimpact"	"Water.BulletImpact"
+
+	"impacthard" "Water.ImpactHard"
+	"impactsoft" "Water.ImpactSoft"
+
+	"audioreflectivity" "0.33"
+	"audioroughnessfactor" "0.1"
+	"audiohardnessfactor" "0.0"
+
+	"gamematerial"	"S"
+}
+
+"jalopy"
+{
+	"base"			"metal"
+	"impacthard"	"ATV_impact_medium"
+	"impactsoft"	"ATV_impact_medium"
+}
+

--- a/sp/game/mod_sdk2013ce/sdk2013ce.fgd
+++ b/sp/game/mod_sdk2013ce/sdk2013ce.fgd
@@ -1,4 +1,4 @@
-//====== Copyright © 1996-2005, Valve Corporation, All rights reserved. =======
+//========= Copyright Valve Corporation, All rights reserved. ============//
 //
 // Purpose: SDK 2013 CE game definition file (.fgd) 
 //

--- a/sp/game/mod_sdk2013ce/sdk2013ce.fgd
+++ b/sp/game/mod_sdk2013ce/sdk2013ce.fgd
@@ -1,0 +1,130 @@
+//====== Copyright © 1996-2005, Valve Corporation, All rights reserved. =======
+//
+// Purpose: SDK 2013 CE game definition file (.fgd) 
+//
+//=============================================================================
+
+@include "base.fgd"
+
+//-------------------------------------------------------------------------
+//
+// NPCs
+//
+//-------------------------------------------------------------------------
+@NPCClass base(BaseHelicopter) studio("models/combine_dropship.mdl" ) = npc_combinedropship : "Combine Dropship"
+[
+	spawnflags(Flags) =
+	[
+		32768 : "Wait for input before dropoff" : 0
+	]
+
+	LandTarget(target_destination) : "Land target name"
+	GunRange(float) : "Crate Gun Range" : 2048 : "If the dropship's carrying a crate with a gun on it, it'll only shoot targets within this range."
+
+	RollermineTemplate(target_destination) : "Name of Rollermine Template" : "" : "If this dropship drops any rollermines due to the 'DropMines' input being fired, it will use this template for the rollermines it creates. If left blank, ordinary rollermines will be dropped."
+
+	NPCTemplate(target_destination) : "Name of Template NPC 1"
+	NPCTemplate2(target_destination) : "Name of Template NPC 2"
+	NPCTemplate3(target_destination) : "Name of Template NPC 3"
+	NPCTemplate4(target_destination) : "Name of Template NPC 4"
+	NPCTemplate5(target_destination) : "Name of Template NPC 5"
+	NPCTemplate6(target_destination) : "Name of Template NPC 6"
+
+	Dustoff1(target_destination) : "Name of dustoff point for NPC 1"
+	Dustoff2(target_destination) : "Name of dustoff point for NPC 2"
+	Dustoff3(target_destination) : "Name of dustoff point for NPC 3"
+	Dustoff4(target_destination) : "Name of dustoff point for NPC 4"
+	Dustoff5(target_destination) : "Name of dustoff point for NPC 5"
+	Dustoff6(target_destination) : "Name of dustoff point for NPC 6"
+
+	APCVehicleName(target_destination) : "Name of the APC to drop"
+	Invulnerable(Choices) : "Invulnerable" : 0 =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	CrateType(Choices) : "Crate Type" : 2 =
+	[
+		-4 : "Jalopy (No crate)"
+		-3 : "Jeep (No crate)"
+		-2 : "APC (No crate)"
+		-1 : "Strider (No crate)"
+		0 : "Roller Hopper"
+		1 : "Soldier Crate"
+		2 : "None"
+	]
+
+	// Inputs
+	input LandLeaveCrate(integer) : "Land, drop soldiers, and leave the crate behind. Specify the number of troops to drop off in the parameter."
+	input LandTakeCrate(integer) : "Land, drop soldiers, but don't leave the crate behind. Specify the number of troops to drop off in the parameter."
+	input DropMines(integer) : "Drop Rollermines. Specify the number of mines to drop in the parameter."
+	input DropStrider(void) : "Drop the Strider you're carrying. Now."
+	input DropAPC(void) : "Drop the APC you're carrying. Now."
+	input Hover(target_destination) : "Hover over a named target entity until told to fly to a path."
+	input Pickup(string) : "Pickup an entity."
+	input SetLandTarget(string) : "Set my land target name."
+	input SetGunRange(float) : "Set my crate gun's range."
+
+	input EnableRotorSound(void) : "Turns on rotor sounds"
+	input DisableRotorSound(void) : "Turns off rotor sounds"
+
+	input StopWaitingForDropoff(void) : "Stop waiting for the dropoff. Dropoff as soon as possible."
+
+
+	// Outputs
+	output OnFinishedDropoff(void)  : "Fires when the dropship has finished a dropoff."
+	output OnFinishedPickup(void) : "Fires when the dropship has finished a pickup."
+
+	output OnCrateShotDownBeforeDropoff(float) : "Fires when the container was shot down before it dropped off soldiers. The parameter contains the number of soldiers that weren't successfully dropped off."
+	output OnCrateShotDownAfterDropoff(void) : "Fires when the container was shot down after it dropped off soldiers."
+
+]
+
+//-------------------------------------------------------------------------
+//
+// Vehicles.
+//
+//-------------------------------------------------------------------------
+@PointClass base(BaseDriveableVehicle) studioprop() = prop_vehicle_jalopy :
+	"Driveable studiomodel jalopy."
+[
+	input StartRemoveTauCannon(void) : "Start the tau removal sequence."
+	input FinishRemoveTauCannon(void) : "Finish the tau removal sequence."
+	
+	// FIXME: These will move into episodic
+	input LockEntrance( void ) : "Stops NPC's from entering the vehicle until unlocked."
+	input UnlockEntrance( void ) : "Allows NPC's to enter the vehicle."
+	input LockExit( void ) : "Stops NPC's from exiting the vehicle until unlocked."
+	input UnlockExit( void ) : "Allows NPC's to exit the vehicle."
+	input EnableRadar( void ) : "Turn on the Jalopy radar"
+	input DisableRadar( void ) : "Turn off the Jalopy radar"
+	input EnableRadarDetectEnemies( void ) : "Enable Jalopy radar to detect Striders and Hunters"
+	input AddBusterToCargo( void ) : "Put a striderbuster in the cargo trigger"
+	input SetCargoHopperVisibility ( bool ) : "Set the strider buster hopper thingy to be visible, or invisible."
+
+	input DisablePhysGun(void) : "Disable physgun interactions with the jeep."
+	input EnablePhysGun(void) : "Enable physgun interactions with the jeep (default)."
+
+	input CreateLinkController(void) : "Automatically builds and attaches a link controller to the car, which cuts the node connections under the car while the car is standing still."
+	input DestroyLinkController(void) : "Destroys the link controller created by CreateLinkController."
+
+	
+	CargoVisible(choices): "Hopper Visible" : 0 : "Is the striderbuster cargo hopper visible?" =
+	[
+		0 : "No"
+		1 : "Yes"
+	]
+
+	spawnflags(Flags) = 
+	[
+		1 : "HUD Locator Precache" : 0
+	]
+
+	
+	// FIXME: These are going to change!
+	output OnCompanionEnteredVehicle(void) : "Companion has entered the vehicle."
+	output OnCompanionExitedVehicle(void) : "Companion has exited the vehicle."
+	output OnHostileEnteredVehicle(void) : "Hostile has entered the vehicle."
+	output OnHostileExitedVehicle(void) : "Hostile has exited the vehicle."
+]

--- a/sp/src/game/server/episodic/vehicle_jeep_episodic.cpp
+++ b/sp/src/game/server/episodic/vehicle_jeep_episodic.cpp
@@ -314,7 +314,11 @@ LINK_ENTITY_TO_CLASS( info_target_vehicle_transition, CInfoTargetVehicleTransiti
 //	CPropJeepEpisodic
 //
 
+#ifdef SDK2013CE
+LINK_ENTITY_TO_CLASS( prop_vehicle_jalopy, CPropJeepEpisodic );
+#else
 LINK_ENTITY_TO_CLASS( prop_vehicle_jeep, CPropJeepEpisodic );
+#endif // SDK2013CE
 
 BEGIN_DATADESC( CPropJeepEpisodic )
 

--- a/sp/src/game/server/episodic/weapon_striderbuster.cpp
+++ b/sp/src/game/server/episodic/weapon_striderbuster.cpp
@@ -270,7 +270,11 @@ void CWeaponStriderBuster::Spawn( void )
 //-----------------------------------------------------------------------------
 void CWeaponStriderBuster::Activate( void )
 {	
+#ifdef SDK2013CE
+	g_iszVehicle = AllocPooledString( "prop_vehicle_jalopy" );
+#else
 	g_iszVehicle = AllocPooledString( "prop_vehicle_jeep" );
+#endif // SDK2013CE
 	BaseClass::Activate();
 }
 

--- a/sp/src/game/server/hl2/item_itemcrate.cpp
+++ b/sp/src/game/server/hl2/item_itemcrate.cpp
@@ -166,8 +166,14 @@ int CItem_ItemCrate::OnTakeDamage( const CTakeDamageInfo &info )
 void CItem_ItemCrate::VPhysicsCollision( int index, gamevcollisionevent_t *pEvent )
 {
 	float flDamageScale = 1.0f;
+#ifndef SDK2013CE
 	if ( FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_airboat" ) ||
 		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep" ) )
+#else
+	if ( FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_airboat" ) ||
+		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jeep" ) ||
+		 FClassnameIs( pEvent->pEntities[!index], "prop_vehicle_jalopy" ) )
+#endif // SDK2013CE
 	{
 		flDamageScale = 100.0f;
 	}

--- a/sp/src/game/server/hl2/npc_combinedropship.cpp
+++ b/sp/src/game/server/hl2/npc_combinedropship.cpp
@@ -84,6 +84,9 @@ enum DROP_STATES
 
 enum CRATE_TYPES 
 {
+#ifdef SDK2013CE
+	CRATE_JALOPY = -4,
+#endif // SDK2013CE
 	CRATE_JEEP = -3,
 	CRATE_APC = -2,
 	CRATE_STRIDER = -1,
@@ -973,6 +976,31 @@ void CNPC_CombineDropship::Spawn( void )
 		}
 		break;
 
+#ifdef SDK2013CE
+	case CRATE_JALOPY:
+		m_hContainer = (CBaseAnimating*)CreateEntityByName( "prop_dynamic_override" );
+		if (m_hContainer)
+		{
+			m_hContainer->SetModel( "models/vehicle.mdl" );
+			m_hContainer->SetName( AllocPooledString( "dropship_jalopy" ) );
+
+			m_hContainer->SetAbsOrigin( GetAbsOrigin() );//- Vector( 0, 0 , 25 ) );
+			QAngle angles = GetAbsAngles();
+			VMatrix mat, rot, result;
+			MatrixFromAngles( angles, mat );
+			MatrixBuildRotateZ( rot, -90 );
+			MatrixMultiply( mat, rot, result );
+			MatrixToAngles( result, angles );
+			m_hContainer->SetAbsAngles( angles );
+
+			m_hContainer->SetParent(this, 0);
+			m_hContainer->SetOwnerEntity(this);
+			m_hContainer->SetSolid( SOLID_VPHYSICS );
+			m_hContainer->Spawn();
+		}
+		break;
+#endif // SDK2013CE
+
 	case CRATE_NONE:
 	default:
 		break;
@@ -1108,6 +1136,12 @@ void CNPC_CombineDropship::Precache( void )
 	case CRATE_JEEP:
 		PrecacheModel("models/buggy.mdl");
 		break;
+
+#ifdef SDK2013CE
+	case CRATE_JALOPY:
+		PrecacheModel("models/vehicle.mdl");
+		break;
+#endif // SDK2013CE
 
 	default:
 		break;

--- a/sp/src/game/server/hl2/vehicle_jeep.cpp
+++ b/sp/src/game/server/hl2/vehicle_jeep.cpp
@@ -144,7 +144,7 @@ IMPLEMENT_SERVERCLASS_ST( CPropJeep, DT_PropJeep )
 END_SEND_TABLE();
 
 // This is overriden for the episodic jeep
-#ifndef HL2_EPISODIC
+#if !defined(HL2_EPISODIC) || defined(SDK2013CE)
 LINK_ENTITY_TO_CLASS( prop_vehicle_jeep, CPropJeep );
 #endif
 

--- a/sp/src/game/server/physobj.cpp
+++ b/sp/src/game/server/physobj.cpp
@@ -1639,7 +1639,11 @@ void CPhysMagnet::VPhysicsCollision( int index, gamevcollisionevent_t *pEvent )
 	if ( HasSpawnFlags( SF_MAGNET_COAST_HACK ) )
 	{
 		// If the other isn't the jeep, we need to get rid of it
+#ifdef SDK2013CE
+		if ( !FClassnameIs( pOther, "prop_vehicle_jalopy" ) )
+#else
 		if ( !FClassnameIs( pOther, "prop_vehicle_jeep" ) )
+#endif // SDK2013CE
 		{
 			// If it takes damage, destroy it
 			if ( pOther->m_takedamage != DAMAGE_NO && pOther->m_takedamage != DAMAGE_EVENTS_ONLY )

--- a/sp/src/game/server/player.cpp
+++ b/sp/src/game/server/player.cpp
@@ -5980,7 +5980,11 @@ static void CreateJalopy( CBasePlayer *pPlayer )
 	// Cheat to create a jeep in front of the player
 	Vector vecForward;
 	AngleVectors( pPlayer->EyeAngles(), &vecForward );
-	CBaseEntity *pJeep = (CBaseEntity *)CreateEntityByName( "prop_vehicle_jeep" );
+#ifdef SDK2013CE
+	CBaseEntity *pJeep = (CBaseEntity *)CreateEntityByName( "prop_vehicle_jalopy" );
+#else
+	CBaseEntity* pJeep = (CBaseEntity *)CreateEntityByName( "prop_vehicle_jeep" );
+#endif // SDK2013CE
 	if ( pJeep )
 	{
 		Vector vecOrigin = pPlayer->GetAbsOrigin() + vecForward * 256 + Vector(0,0,64);
@@ -5989,7 +5993,11 @@ static void CreateJalopy( CBasePlayer *pPlayer )
 		pJeep->SetAbsAngles( vecAngles );
 		pJeep->KeyValue( "model", "models/vehicle.mdl" );
 		pJeep->KeyValue( "solid", "6" );
-		pJeep->KeyValue( "targetname", "jeep" );
+#ifdef SDK2013CE
+		pJeep->KeyValue( "targetname", "jalopy" );
+#else
+		pJeep->KeyValue("targetname", "jeep");
+#endif // SDK2013CE
 		pJeep->KeyValue( "vehiclescript", "scripts/vehicles/jalopy.txt" );
 		DispatchSpawn( pJeep );
 		pJeep->Activate();

--- a/sp/src/game/shared/episodic/achievements_ep2.cpp
+++ b/sp/src/game/shared/episodic/achievements_ep2.cpp
@@ -60,7 +60,11 @@ protected:
 	virtual void Init() 
 	{
 		SetFlags( ACH_LISTEN_KILL_ENEMY_EVENTS | ACH_SAVE_WITH_GAME );
+#ifdef SDK2013CE
+		SetInflictorFilter( "prop_vehicle_jalopy" );
+#else
 		SetInflictorFilter( "prop_vehicle_jeep" );
+#endif // SDK2013CE
 		SetGameDirFilter( "ep2" );
 		SetGoal( 20 );
 	}

--- a/sp/src/public/steam/steam_api.h
+++ b/sp/src/public/steam/steam_api.h
@@ -548,7 +548,6 @@ inline bool CSteamAPIContext::Init()
 		return false;
 	}
 
-#ifndef SDK2013CE
 	m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
 	if ( !m_pSteamMusicRemote )
 	{
@@ -560,7 +559,6 @@ inline bool CSteamAPIContext::Init()
 	{
 		return false;
 	}
-#endif // !SDK2013CE
 
 #ifdef _PS3
 	m_pSteamPS3OverlayRender = SteamClient()->GetISteamPS3OverlayRender();

--- a/sp/src/public/steam/steam_api.h
+++ b/sp/src/public/steam/steam_api.h
@@ -548,7 +548,8 @@ inline bool CSteamAPIContext::Init()
 		return false;
 	}
 
-	/*m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote(hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION);
+#ifndef SDK2013CE
+	m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
 	if ( !m_pSteamMusicRemote )
 	{
 		return false;
@@ -558,7 +559,8 @@ inline bool CSteamAPIContext::Init()
 	if ( !m_pSteamHTMLSurface )
 	{
 		return false;
-	}*/
+	}
+#endif // !SDK2013CE
 
 #ifdef _PS3
 	m_pSteamPS3OverlayRender = SteamClient()->GetISteamPS3OverlayRender();

--- a/sp/src/public/steam/steam_api.h
+++ b/sp/src/public/steam/steam_api.h
@@ -548,7 +548,7 @@ inline bool CSteamAPIContext::Init()
 		return false;
 	}
 
-	m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote( hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION );
+	/*m_pSteamMusicRemote = SteamClient()->GetISteamMusicRemote(hSteamUser, hSteamPipe, STEAMMUSICREMOTE_INTERFACE_VERSION);
 	if ( !m_pSteamMusicRemote )
 	{
 		return false;
@@ -558,7 +558,7 @@ inline bool CSteamAPIContext::Init()
 	if ( !m_pSteamHTMLSurface )
 	{
 		return false;
-	}
+	}*/
 
 #ifdef _PS3
 	m_pSteamPS3OverlayRender = SteamClient()->GetISteamPS3OverlayRender();


### PR DESCRIPTION
I'm not sure if I should've added the `gameinfo.txt`, but it's just the mod_episodic one.

### TODO
- [x] Crashes due to the materials.
- [ ] Late precaching asserts.

### Changes

1. ~~Applied [startup crash fix](https://github.com/PiMoNFeeD/source-sdk-2013-mod/commit/a48ed285e3c3f40c27a2a46530092a7abf31a1c9). No need for upcoming beta.~~
2. Added `scripts/surfaceproperties_ep2.txt`. Fixes jalopy crashing
3. `npc_combinedropship` can hold the jalopy(CrateType = -4).

![image](https://user-images.githubusercontent.com/52358442/165018043-046a2679-5757-49a2-a5fe-28a6bbc88b3a.png)