### PR TITLE
ent_create crash fix | 

### DIFF
--- a/mp/src/game/server/ai_basenpc.cpp
+++ b/mp/src/game/server/ai_basenpc.cpp
@@ -6560,11 +6560,15 @@ float CAI_BaseNPC::ThrowLimit(	const Vector &vecStart,
 //-----------------------------------------------------------------------------
 void CAI_BaseNPC::SetupVPhysicsHull()
 {
+	#ifdef SDK2013CE
+
 	if ( GetModelPtr() == NULL )
 	{
 		UTIL_Remove(this);
 		return;
 	}
+
+	#endif
 
 	if ( GetMoveType() == MOVETYPE_VPHYSICS || GetMoveType() == MOVETYPE_NONE )
 		return;

--- a/mp/src/game/server/ai_basenpc.cpp
+++ b/mp/src/game/server/ai_basenpc.cpp
@@ -6560,6 +6560,12 @@ float CAI_BaseNPC::ThrowLimit(	const Vector &vecStart,
 //-----------------------------------------------------------------------------
 void CAI_BaseNPC::SetupVPhysicsHull()
 {
+	if ( GetModelPtr() == NULL )
+	{
+		UTIL_Remove(this);
+		return;
+	}
+
 	if ( GetMoveType() == MOVETYPE_VPHYSICS || GetMoveType() == MOVETYPE_NONE )
 		return;
 

--- a/mp/src/public/bone_setup.cpp
+++ b/mp/src/public/bone_setup.cpp
@@ -5928,10 +5928,14 @@ const char *Studio_GetDefaultSurfaceProps( CStudioHdr *pstudiohdr )
 
 float Studio_GetMass( CStudioHdr *pstudiohdr )
 {
+	#ifdef SDK2013CE
+	
 	if ( pstudiohdr == NULL )
 	{
 		return 0.f;
 	}
+
+	#endif
 
 	return pstudiohdr->mass();
 }

--- a/mp/src/public/bone_setup.cpp
+++ b/mp/src/public/bone_setup.cpp
@@ -2623,14 +2623,14 @@ public:
          X[i] = P[i];
       normalize(X);
 
-// Its y axis is perpendicular to P, so Y = unit( E - X(E·X) ).
+// Its y axis is perpendicular to P, so Y = unit( E - X(Eï¿½X) ).
 
       float dDOTx = dot(D,X);
       for (i = 0 ; i < 3 ; i++)
          Y[i] = D[i] - dDOTx * X[i];
       normalize(Y);
 
-// Its z axis is perpendicular to both X and Y, so Z = X×Y.
+// Its z axis is perpendicular to both X and Y, so Z = Xï¿½Y.
 
       cross(X,Y,Z);
 
@@ -5928,6 +5928,11 @@ const char *Studio_GetDefaultSurfaceProps( CStudioHdr *pstudiohdr )
 
 float Studio_GetMass( CStudioHdr *pstudiohdr )
 {
+	if ( pstudiohdr == NULL )
+	{
+		return 0.f;
+	}
+
 	return pstudiohdr->mass();
 }
 

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -6560,11 +6560,15 @@ float CAI_BaseNPC::ThrowLimit(	const Vector &vecStart,
 //-----------------------------------------------------------------------------
 void CAI_BaseNPC::SetupVPhysicsHull()
 {
+	#ifdef SDK2013CE
+	
 	if ( GetModelPtr() == NULL )
 	{
 		UTIL_Remove(this);
 		return;
 	}
+
+	#endif
 
 	if ( GetMoveType() == MOVETYPE_VPHYSICS || GetMoveType() == MOVETYPE_NONE )
 		return;

--- a/sp/src/game/server/ai_basenpc.cpp
+++ b/sp/src/game/server/ai_basenpc.cpp
@@ -6560,6 +6560,12 @@ float CAI_BaseNPC::ThrowLimit(	const Vector &vecStart,
 //-----------------------------------------------------------------------------
 void CAI_BaseNPC::SetupVPhysicsHull()
 {
+	if ( GetModelPtr() == NULL )
+	{
+		UTIL_Remove(this);
+		return;
+	}
+
 	if ( GetMoveType() == MOVETYPE_VPHYSICS || GetMoveType() == MOVETYPE_NONE )
 		return;
 

--- a/sp/src/public/bone_setup.cpp
+++ b/sp/src/public/bone_setup.cpp
@@ -2623,14 +2623,14 @@ public:
          X[i] = P[i];
       normalize(X);
 
-// Its y axis is perpendicular to P, so Y = unit( E - X(E·X) ).
+// Its y axis is perpendicular to P, so Y = unit( E - X(Eï¿½X) ).
 
       float dDOTx = dot(D,X);
       for (i = 0 ; i < 3 ; i++)
          Y[i] = D[i] - dDOTx * X[i];
       normalize(Y);
 
-// Its z axis is perpendicular to both X and Y, so Z = X×Y.
+// Its z axis is perpendicular to both X and Y, so Z = Xï¿½Y.
 
       cross(X,Y,Z);
 
@@ -5924,6 +5924,11 @@ const char *Studio_GetDefaultSurfaceProps( CStudioHdr *pstudiohdr )
 
 float Studio_GetMass( CStudioHdr *pstudiohdr )
 {
+	if ( pstudiohdr == NULL )
+	{
+		return 0.f;
+	}
+
 	return pstudiohdr->mass();
 }
 

--- a/sp/src/public/bone_setup.cpp
+++ b/sp/src/public/bone_setup.cpp
@@ -5924,10 +5924,14 @@ const char *Studio_GetDefaultSurfaceProps( CStudioHdr *pstudiohdr )
 
 float Studio_GetMass( CStudioHdr *pstudiohdr )
 {
+	#ifdef SDK2013CE
+
 	if ( pstudiohdr == NULL )
 	{
 		return 0.f;
 	}
+
+	#endif
 
 	return pstudiohdr->mass();
 }


### PR DESCRIPTION
Checking if studio mdl ptr is not null! Other wise  will crash!

You can reproduce the crash without the fix if you spawn a entity like this inside the console: `ent_create npc_combine`
