### PR TITLE
Don't network info_null

### DIFF
--- a/mp/src/game/server/subs.cpp
+++ b/mp/src/game/server/subs.cpp
@@ -22,10 +22,10 @@ void CPointEntity::Spawn( void )
 }
 
 
-class CNullEntity : public CBaseEntity
+class CNullEntity : public CServerOnlyEntity
 {
 public:
-	DECLARE_CLASS( CNullEntity, CBaseEntity );
+	DECLARE_CLASS( CNullEntity, CServerOnlyEntity );
 
 	void Spawn( void );
 };

--- a/sp/src/game/server/subs.cpp
+++ b/sp/src/game/server/subs.cpp
@@ -22,10 +22,10 @@ void CPointEntity::Spawn( void )
 }
 
 
-class CNullEntity : public CBaseEntity
+class CNullEntity : public CServerOnlyEntity
 {
 public:
-	DECLARE_CLASS( CNullEntity, CBaseEntity );
+	DECLARE_CLASS( CNullEntity, CServerOnlyEntity );
 
 	void Spawn( void );
 };


### PR DESCRIPTION
Reduces potential for entity limit crashes, as it still exists for the first tick